### PR TITLE
refactor: 도메인별 API 클라이언트 계층 도입

### DIFF
--- a/front/etf-recommendation/app/etf/[id]/action.ts
+++ b/front/etf-recommendation/app/etf/[id]/action.ts
@@ -1,74 +1,61 @@
-'use server'
-import {cookies} from "next/headers";
+'use server';
+import { cookies } from 'next/headers';
+import {
+  subscribeToEtf as apiSubscribeToEtf,
+  unsubscribeFromEtf as apiUnsubscribeFromEtf,
+  fetchSubscribedEtfs,
+} from '@/lib/api/subscription';
 
 export async function subscribeToEtf(etfId: number) {
-    const cookieStore = await cookies()
-    const accessToken = cookieStore.get('accessToken')?.value
-    // if (!accessToken) {
-    //     throw new Error('로그인이 필요합니다')
-    // }
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+  if (!accessToken) {
+    throw new Error('로그인이 필요합니다');
+  }
 
-    const res = await fetch(`https://localhost:8443/api/v1/etfs/${etfId}/subscription`, {
-        method: 'POST',
-        headers: {
-            Authorization: `Bearer ${accessToken}`,
-            'Content-Type': 'application/json',
-        },
-    })
+  const { data, error } = await apiSubscribeToEtf(etfId, accessToken);
 
-    if (!res.ok) {
-        const error = await res.json()
-        throw new Error(error.message || '구독 실패')
-    }
+  if (error) {
+    throw new Error(error || '구독 실패');
+  }
 
-    return await res.json()
+  return data;
 }
+
 export async function unsubscribeFromEtf(etfId: number) {
-    const cookieStore = await cookies()
-    const accessToken = cookieStore.get('accessToken')?.value
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
 
-    // 토큰이 없을 경우 에러 처리
-    if (!accessToken) {
-        throw new Error('로그인이 필요합니다')
-    }
+  // 토큰이 없을 경우 에러 처리
+  if (!accessToken) {
+    throw new Error('로그인이 필요합니다');
+  }
 
-    const res = await fetch(`https://localhost:8443/api/v1/etf/${etfId}/subscription`, {
-        method: 'DELETE',
-        headers: {
-            Authorization: `Bearer ${accessToken}`,
-            'Content-Type': 'application/json',
-        },
-    })
+  const { data, error } = await apiUnsubscribeFromEtf(etfId, accessToken);
 
-    if (!res.ok) {
-        const error = await res.json()
-        throw new Error(error.message || '구독 취소 실패')
-    }
+  if (error) {
+    throw new Error(error || '구독 취소 실패');
+  }
 
-    return await res.json()  // 성공한 경우 반환
+  return data;
 }
 
 export async function getSubscribedEtfIds(): Promise<number[]> {
-    const cookieStore = await cookies()
-    const accessToken = cookieStore.get('accessToken')?.value
-    if (!accessToken) return []
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+  if (!accessToken) return [];
 
-    const res = await fetch(`https://localhost:8443/api/v1/etfs/subscribes`, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-    })
-    if (!res.ok) return []
+  const { data, error } = await fetchSubscribedEtfs(accessToken);
 
-    try {
-        const data = await res.json()
+  if (error || !data) {
+    console.error('구독 정보 불러오기 실패', error);
+    return [];
+  }
 
-        if (data && Array.isArray(data.subscribeResponseList)) {
-            return data.subscribeResponseList.map((s: any) => s.etfId)
-    } else {
-        console.error('Invalid response format or empty subscribes', data)
-        return [] // 형식이 잘못된 경우 빈 배열 리턴
-    }
-} catch (error) {
-    console.error('Error parsing response', error)
-    return []  // 파싱 오류가 발생한 경우 빈 배열 리턴
-}
+  if (data && Array.isArray(data.subscribeResponseList)) {
+    return data.subscribeResponseList.map((s: any) => s.etfId);
+  } else {
+    console.error('Invalid response format or empty subscribes', data);
+    return [];
+  }
 }

--- a/front/etf-recommendation/app/etf/[id]/page.tsx
+++ b/front/etf-recommendation/app/etf/[id]/page.tsx
@@ -1,103 +1,107 @@
-'use client'
+'use client';
 
-import {useParams, useRouter} from 'next/navigation'
-import {useEffect, useState, useTransition} from 'react'
-import { notFound } from 'next/navigation'
-import { ArrowLeft, Star, StarHalf } from 'lucide-react'
-import Link from 'next/link'
-import TradingViewWidget from "@/components/tradingViewWidget";
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useState, useTransition } from 'react';
+import { notFound } from 'next/navigation';
+import { ArrowLeft, Star, StarHalf } from 'lucide-react';
+import Link from 'next/link';
+import TradingViewWidget from '@/components/tradingViewWidget';
 
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from '@/components/ui/tabs'
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import {getSubscribedEtfIds, subscribeToEtf, unsubscribeFromEtf} from "@/app/etf/[id]/action";
-
+  getSubscribedEtfIds,
+  subscribeToEtf,
+  unsubscribeFromEtf,
+} from '@/app/etf/[id]/action';
+import { fetchEtfDetail } from '@/lib/api/etf';
 
 type Holding = {
-  name: string
-  weight: number
-}
+  name: string;
+  weight: number;
+};
 
 type ETF = {
-  id: number
-  name: string
-  ticker: string
-  issuer: string
-  theme: string
-  description: string
-  price: number
-  nav: number
-  change: number
-  returnRate: number
-  volume: number
-  launchDate: string
-  aum: number
-  expense: number
-  holdings: Holding[]
+  id: number;
+  name: string;
+  ticker: string;
+  issuer: string;
+  theme: string;
+  description: string;
+  price: number;
+  nav: number;
+  change: number;
+  returnRate: number;
+  volume: number;
+  launchDate: string;
+  aum: number;
+  expense: number;
+  holdings: Holding[];
   chartData: {
-    daily: any[]
-    weekly: any[]
-    monthly: any[]
-    yearly: any[]
-  }
-}
+    daily: any[];
+    weekly: any[];
+    monthly: any[];
+    yearly: any[];
+  };
+};
 
 export default function ETFDetailPage() {
-  const params = useParams()
-  const etfId = params.id// URL에서 id 값을 가져옴
-  const [etf, setEtf] = useState<ETF | null>(null)
-  const router = useRouter()
-  const [subscribed, setSubscribed] = useState(false) // 구독 상태
-  const [loading, setLoading] = useState(false)
-  const [isPending, startTransition] = useTransition()
+  const params = useParams();
+  const etfId = params.id as string; // URL에서 id 값을 가져옴
+  const [etf, setEtf] = useState<ETF | null>(null);
+  const router = useRouter();
+  const [subscribed, setSubscribed] = useState(false); // 구독 상태
+  const [loading, setLoading] = useState(false);
+  const [isPending, startTransition] = useTransition();
 
   useEffect(() => {
-    if (!etfId) return
+    if (!etfId) return;
 
-    fetch(`https://localhost:8443/api/v1/etfs/${etfId}`)
-        .then(res => {
-          if (!res.ok) throw new Error('ETF not found')
-          return res.json()
-        })
-        .then(data => {
-          setEtf({
-            id: data.etfId,
-            name: data.etfName,
-            ticker: data.etfCode,
-            issuer: data.companyName,
-            theme: '',  // theme 데이터가 없으므로 비워둡니다.
-            description: '', // description 데이터가 없으므로 비워둡니다.
-            price: 0, // 가격 데이터가 없으므로 0으로 설정
-            nav: 0, // NAV 데이터가 없으므로 0으로 설정
-            change: 0, // 변화율 데이터가 없으므로 0으로 설정
-            returnRate: 0, // 수익률 데이터가 없으므로 0으로 설정
-            volume: 0, // 거래량 데이터가 없으므로 0으로 설정
-            launchDate: data.listingDate,
-            aum: 0, // 자산 규모가 없으므로 0으로 설정
-            expense: 0, // 보수율이 없으므로 0으로 설정
-            holdings: [], // 구성 종목 데이터가 없으므로 빈 배열로 설정
-            chartData: {
-              daily: [],
-              weekly: [],
-              monthly: [],
-              yearly: [],
-            },
-          })
-        })
-        .catch(() => notFound()) // 오류 발생 시 404 페이지로 이동
-  },[etfId]);
+    const loadEtfDetail = async () => {
+      const { data, error } = await fetchEtfDetail(Number(etfId));
+
+      if (error || !data) {
+        console.error('ETF not found', error);
+        notFound();
+      }
+
+      setEtf({
+        id: data.etfId,
+        name: data.etfName,
+        ticker: data.etfCode,
+        issuer: data.companyName,
+        theme: '', // theme 데이터가 없으므로 비워둡니다.
+        description: '', // description 데이터가 없으므로 비워둡니다.
+        price: 0, // 가격 데이터가 없으므로 0으로 설정
+        nav: 0, // NAV 데이터가 없으므로 0으로 설정
+        change: 0, // 변화율 데이터가 없으므로 0으로 설정
+        returnRate: 0, // 수익률 데이터가 없으므로 0으로 설정
+        volume: 0, // 거래량 데이터가 없으므로 0으로 설정
+        launchDate: data.listingDate,
+        aum: 0, // 자산 규모가 없으므로 0으로 설정
+        expense: 0, // 보수율이 없으므로 0으로 설정
+        holdings: [], // 구성 종목 데이터가 없으므로 빈 배열로 설정
+        chartData: {
+          daily: [],
+          weekly: [],
+          monthly: [],
+          yearly: [],
+        },
+      });
+    };
+
+    loadEtfDetail();
+  }, [etfId]);
 
   useEffect(() => {
     if (!etfId) return;
@@ -111,176 +115,200 @@ export default function ETFDetailPage() {
   }, [etfId]);
 
   const handleToggleSubscribe = async () => {
-    setLoading(true)
+    setLoading(true);
     try {
       if (subscribed) {
-        await unsubscribeFromEtf(etfId) // 구독 취소
-        setSubscribed(false)
+        await unsubscribeFromEtf(+etfId); // 구독 취소
+        setSubscribed(false);
       } else {
-        await subscribeToEtf(etfId) // 구독
-        setSubscribed(true)
+        await subscribeToEtf(+etfId); // 구독
+        setSubscribed(true);
       }
     } catch (err: any) {
-      alert(err.message)
+      alert(err.message);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
-  if (!etf) return <div className="p-6">ETF 데이터를 불러오는 중입니다...</div>
+  if (!etf) return <div className="p-6">ETF 데이터를 불러오는 중입니다...</div>;
 
-  const tradingViewSymbol = `KRX:${etf.ticker.toUpperCase()}`
-  const relatedEtfs: ETF[] = [] // 필요시 관련 ETF 데이터 로직 추가
+  const tradingViewSymbol = `KRX:${etf.ticker.toUpperCase()}`;
+  const relatedEtfs: ETF[] = []; // 필요시 관련 ETF 데이터 로직 추가
 
   return (
-      <div className="container mx-auto py-6 px-4">
-        <div className="mb-6">
-          <Link href="/" className="flex items-center gap-1 text-slate-500 hover:text-slate-700 mb-4">
-            <ArrowLeft className="h-4 w-4" />
-            <span>홈으로 돌아가기</span>
-          </Link>
+    <div className="container mx-auto py-6 px-4">
+      <div className="mb-6">
+        <Link
+          href="/"
+          className="flex items-center gap-1 text-slate-500 hover:text-slate-700 mb-4"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          <span>홈으로 돌아가기</span>
+        </Link>
 
-          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-            <div>
-              <div className="flex items-center gap-2">
-                <h1 className="text-3xl font-bold">{etf.name}</h1>
-                <Badge variant="outline">{etf.theme}</Badge>
-              </div>
-              <p className="text-slate-500">
-                {etf.ticker} | {etf.issuer}
-              </p>
-            </div>
-
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
             <div className="flex items-center gap-2">
-              <Button
-                  variant={subscribed ? 'secondary' : 'outline'}
-                  size="icon"
-                  onClick={handleToggleSubscribe}
-                  disabled={loading}
-              >
-                {subscribed ? (
-                    <Star className="h-4 w-4 text-yellow-500" />
-                ) : (
-                    <Star className="h-4 w-4" />
-                )}
-              </Button>
+              <h1 className="text-3xl font-bold">{etf.name}</h1>
+              <Badge variant="outline">{etf.theme}</Badge>
             </div>
+            <p className="text-slate-500">
+              {etf.ticker} | {etf.issuer}
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              variant={subscribed ? 'secondary' : 'outline'}
+              size="icon"
+              onClick={handleToggleSubscribe}
+              disabled={loading}
+            >
+              {subscribed ? (
+                <Star className="h-4 w-4 text-yellow-500" />
+              ) : (
+                <Star className="h-4 w-4" />
+              )}
+            </Button>
           </div>
         </div>
-
-        <div className="grid md:grid-cols-3 gap-6 mb-8">
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle>현재가</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-end gap-2">
-                <div className="text-3xl font-bold">{etf.price ? etf.price.toLocaleString() : 'Loading...'}원</div>
-                <div className={`text-lg ${etf.change >= 0 ? "text-green-600" : "text-red-600"}`}>
-                  {etf.change >= 0 ? "+" : ""}
-                  {etf.change}%
-                </div>
-              </div>
-              {/*<p className="text-sm text-slate-500 mt-1">NAV: {etf.nav ? etf.nav.toLocaleString() : 'Loading...'}원</p>*/}
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle>등락률</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-3xl font-bold text-green-600">+{etf.returnRate}%</div>
-              {/*<p className="text-sm text-slate-500 mt-1">오늘 기준</p>*/}
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle>거래량</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-3xl font-bold"> {etf.volume ? etf.volume.toLocaleString() : 'Loading...'}</div>
-              {/*<p className="text-sm text-slate-500 mt-1">오늘 기준</p>*/}
-            </CardContent>
-          </Card>
-        </div>
-
-        <div className="mb-8">
-          <Tabs defaultValue="daily">
-            <div className="flex justify-between items-center mb-4">
-              <h2 className="text-2xl font-bold">가격 차트</h2>
-              <TabsList>
-                <TabsTrigger value="daily">일간</TabsTrigger>
-                <TabsTrigger value="weekly">주간</TabsTrigger>
-                <TabsTrigger value="monthly">월간</TabsTrigger>
-                <TabsTrigger value="yearly">연간</TabsTrigger>
-              </TabsList>
-            </div>
-
-
-            <div className="w-full h-[500px]">
-              <TradingViewWidget />
-            </div>
-            차트 부분
-
-            <TabsContent value="daily">
-              {/*<ETFChart data={etf.chartData.daily} title="일간 차트" />*/}
-            </TabsContent>
-            <TabsContent value="weekly">
-              {/*<ETFChart data={etf.chartData.weekly} title="주간 차트" />*/}
-            </TabsContent>
-            <TabsContent value="monthly">
-              {/*<ETFChart data={etf.chartData.monthly} title="월간 차트" />*/}
-            </TabsContent>
-            <TabsContent value="yearly">
-              {/*<ETFChart data={etf.chartData.yearly} title="연간 차트" color={etf.change >= 0 ? "#22c55e" : "#ef4444"} />*/}
-            </TabsContent>
-          </Tabs>
-        </div>
-
-        <div className="grid md:grid-cols-2 gap-6 mb-8">
-          <Card>
-            <CardHeader><CardTitle>ETF 정보</CardTitle></CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                <p>{etf.description || '상세 정보가 없습니다.'}</p>
-                <div className="grid grid-cols-2 gap-4">
-                  <div><p className="text-sm text-slate-500">운용사</p><p className="font-medium">{etf.issuer}</p></div>
-                  <div><p className="text-sm text-slate-500">상장일</p><p className="font-medium">{etf.launchDate}</p></div>
-
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader><CardTitle>구성 종목</CardTitle></CardHeader>
-            <CardContent>
-              {/* holdings가 존재하고 배열인지 체크 */}
-              {etf.holdings && Array.isArray(etf.holdings) && etf.holdings.length > 0 ? (
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>종목명</TableHead>
-                        <TableHead className="text-right">비중</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {etf.holdings.map((holding, index) => (
-                          <TableRow key={index}>
-                            <TableCell>{holding.name}</TableCell>
-                            <TableCell className="text-right">{holding.weight}%</TableCell>
-                          </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-              ) : (
-                  <div className="text-gray-500">구성 종목 데이터가 없습니다.</div>
-              )}
-            </CardContent>
-          </Card>
-        </div>
       </div>
-  )
+
+      <div className="grid md:grid-cols-3 gap-6 mb-8">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle>현재가</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-end gap-2">
+              <div className="text-3xl font-bold">
+                {etf.price ? etf.price.toLocaleString() : 'Loading...'}원
+              </div>
+              <div
+                className={`text-lg ${
+                  etf.change >= 0 ? 'text-green-600' : 'text-red-600'
+                }`}
+              >
+                {etf.change >= 0 ? '+' : ''}
+                {etf.change}%
+              </div>
+            </div>
+            {/*<p className="text-sm text-slate-500 mt-1">NAV: {etf.nav ? etf.nav.toLocaleString() : 'Loading...'}원</p>*/}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle>등락률</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold text-green-600">
+              +{etf.returnRate}%
+            </div>
+            {/*<p className="text-sm text-slate-500 mt-1">오늘 기준</p>*/}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle>거래량</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold">
+              {' '}
+              {etf.volume ? etf.volume.toLocaleString() : 'Loading...'}
+            </div>
+            {/*<p className="text-sm text-slate-500 mt-1">오늘 기준</p>*/}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="mb-8">
+        <Tabs defaultValue="daily">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-2xl font-bold">가격 차트</h2>
+            <TabsList>
+              <TabsTrigger value="daily">일간</TabsTrigger>
+              <TabsTrigger value="weekly">주간</TabsTrigger>
+              <TabsTrigger value="monthly">월간</TabsTrigger>
+              <TabsTrigger value="yearly">연간</TabsTrigger>
+            </TabsList>
+          </div>
+          <div className="w-full h-[500px]">
+            <TradingViewWidget />
+          </div>
+          차트 부분
+          <TabsContent value="daily">
+            {/*<ETFChart data={etf.chartData.daily} title="일간 차트" />*/}
+          </TabsContent>
+          <TabsContent value="weekly">
+            {/*<ETFChart data={etf.chartData.weekly} title="주간 차트" />*/}
+          </TabsContent>
+          <TabsContent value="monthly">
+            {/*<ETFChart data={etf.chartData.monthly} title="월간 차트" />*/}
+          </TabsContent>
+          <TabsContent value="yearly">
+            {/*<ETFChart data={etf.chartData.yearly} title="연간 차트" color={etf.change >= 0 ? "#22c55e" : "#ef4444"} />*/}
+          </TabsContent>
+        </Tabs>
+      </div>
+
+      <div className="grid md:grid-cols-2 gap-6 mb-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>ETF 정보</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              <p>{etf.description || '상세 정보가 없습니다.'}</p>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-sm text-slate-500">운용사</p>
+                  <p className="font-medium">{etf.issuer}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-slate-500">상장일</p>
+                  <p className="font-medium">{etf.launchDate}</p>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>구성 종목</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {/* holdings가 존재하고 배열인지 체크 */}
+            {etf.holdings &&
+            Array.isArray(etf.holdings) &&
+            etf.holdings.length > 0 ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>종목명</TableHead>
+                    <TableHead className="text-right">비중</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {etf.holdings.map((holding, index) => (
+                    <TableRow key={index}>
+                      <TableCell>{holding.name}</TableCell>
+                      <TableCell className="text-right">
+                        {holding.weight}%
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <div className="text-gray-500">구성 종목 데이터가 없습니다.</div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
 }

--- a/front/etf-recommendation/app/page.tsx
+++ b/front/etf-recommendation/app/page.tsx
@@ -201,9 +201,16 @@ export default function Home() {
       );
     }
 
-    return result.sort(
-      (a, b) => b[sortKey as keyof ETF] - a[sortKey as keyof ETF]
-    );
+    return result.sort((a, b) => {
+      const valueA = a[sortKey as keyof ETF];
+      const valueB = b[sortKey as keyof ETF];
+
+      if (typeof valueA === 'number' && typeof valueB === 'number') {
+        return valueB - valueA;
+      }
+
+      return String(valueB).localeCompare(String(valueA));
+    });
   }, [etfData, selectedTheme, searchQuery, sortKey]);
 
   const handleLoadMore = () => {

--- a/front/etf-recommendation/app/page.tsx
+++ b/front/etf-recommendation/app/page.tsx
@@ -1,55 +1,71 @@
-"use client"
-import {useEffect, useMemo, useState} from 'react'
-import Link from "next/link"
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Search, TrendingUp, BarChart3, ArrowUpRight, ArrowDownRight, Filter } from "lucide-react"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import EtfCard from "@/components/EtfCard";
-import MarketTickerWidget from "@/components/MarketTickerWidget";
-// 샘플 ETF 데이터
+'use client';
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Search,
+  TrendingUp,
+  BarChart3,
+  ArrowUpRight,
+  ArrowDownRight,
+  Filter,
+} from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import EtfCard, { ETF } from '@/components/EtfCard';
+import MarketTickerWidget from '@/components/MarketTickerWidget';
+import { fetchAllEtfs, fetchEtfsPage } from '@/lib/api/etf';
 
-type ETF = {
-  id: number
-  name: string
-  ticker: string
-  theme: string
-  price: number
-  change: number
-  volume: number
-  returnRate: number
-}
 // 시장 요약 데이터
 const marketSummary = {
   kospi: { value: 2850.12, change: 1.2 },
   kosdaq: { value: 920.45, change: -0.5 },
   nasdaq: { value: 16250.8, change: 0.8 },
   sp500: { value: 5120.35, change: 0.6 },
-}
-const themeNameMap: Record<string, string> = {
-  'AI_DATA': 'AI 데이터',
-  'USA': '미국',
-  'KOREA': '한국',
-  'REITS': '리츠',
-  'MULTI_ASSET': '멀티에셋',
-  'COMMODITIES': '원자재',
-  'HIGH_RISK': '고위험',
-  'SECTOR': '섹터',
-  'DIVIDEND': '배당',
-  'ESG': 'ESG',
-  'GOLD': '금',
-  'GOVERNMENT_BOND': '국채',
-  'CORPORATE_BOND': '회사채',
-  'DEFENSE': '방위산업',
-  'SEMICONDUCTOR': '반도체',
-  'BIO': '바이오',
-  'EMERGING_MARKETS': '신흥시장'
 };
-
+const themeNameMap: Record<string, string> = {
+  AI_DATA: 'AI 데이터',
+  USA: '미국',
+  KOREA: '한국',
+  REITS: '리츠',
+  MULTI_ASSET: '멀티에셋',
+  COMMODITIES: '원자재',
+  HIGH_RISK: '고위험',
+  SECTOR: '섹터',
+  DIVIDEND: '배당',
+  ESG: 'ESG',
+  GOLD: '금',
+  GOVERNMENT_BOND: '국채',
+  CORPORATE_BOND: '회사채',
+  DEFENSE: '방위산업',
+  SEMICONDUCTOR: '반도체',
+  BIO: '바이오',
+  EMERGING_MARKETS: '신흥시장',
+};
 
 export default function Home() {
   const [searchQuery, setSearchQuery] = useState('');
@@ -62,22 +78,29 @@ export default function Home() {
 
   //전체 데이터 (allEtfData) 최초 로딩
   useEffect(() => {
-    const fetchAllEtfs = async () => {
+    const fetchAllEtfsData = async () => {
       try {
-        const res = await fetch(`https://localhost:8443/api/v1/etfs?page=1&size=10000&period=weekly`);
-        const data = await res.json();
+        const { data, error } = await fetchAllEtfs('weekly');
 
-        const allEtfs: ETF[] = data.etfReadResponseList.map((etf: any, index: number) => ({
-          id: etf.etfId,
-          name: etf.etfName,
-          ticker: etf.etfCode,
-          theme: etf.theme,
-          price: 10000 + index * 100,
-          change: parseFloat((Math.random() * 5).toFixed(2)) * (Math.random() > 0.5 ? 1 : -1),
-          volume: Math.floor(Math.random() * 100000),
-          returnRate: etf.returnRate,
-        }));
+        if (error || !data) {
+          console.error('전체 ETF 로딩 실패', error);
+          return;
+        }
 
+        const allEtfs: ETF[] = data.etfReadResponseList.map(
+          (etf: any, index: number) => ({
+            id: etf.etfId,
+            name: etf.etfName,
+            ticker: etf.etfCode,
+            theme: etf.theme,
+            price: 10000 + index * 100,
+            change:
+              parseFloat((Math.random() * 5).toFixed(2)) *
+              (Math.random() > 0.5 ? 1 : -1),
+            volume: Math.floor(Math.random() * 100000),
+            returnRate: etf.returnRate,
+          })
+        );
 
         setAllEtfData(allEtfs);
       } catch (error) {
@@ -85,29 +108,38 @@ export default function Home() {
       }
     };
 
-    fetchAllEtfs();
+    fetchAllEtfsData();
   }, []);
-//페이지네이션 로딩
+
+  //페이지네이션 로딩
   useEffect(() => {
-    const fetchEtfPage = async () => {
+    const fetchEtfPageData = async () => {
       try {
-        const res = await fetch(`https://localhost:8443/api/v1/etfs?page=${page}&size=20&period=weekly`);
-        const data = await res.json();
+        const { data, error } = await fetchEtfsPage(page, 20, 'weekly');
 
-        const pageEtfs: ETF[] = data.etfReadResponseList.map((etf: any,index:number) => ({
-          id: etf.etfId,
-          name: etf.etfName,
-          ticker: etf.etfCode,
-          theme: etf.theme,
-          price: 10000 + index * 100,
-          change: parseFloat((Math.random() * 5).toFixed(2)) * (Math.random() > 0.5 ? 1 : -1),
-          volume: Math.floor(Math.random() * 100000),
-          returnRate: etf.returnRate,
-        }));
+        if (error || !data) {
+          console.error('ETF 페이지 로딩 실패', error);
+          return;
+        }
 
-        setEtfData(prev => {
+        const pageEtfs: ETF[] = data.etfReadResponseList.map(
+          (etf: any, index: number) => ({
+            id: etf.etfId,
+            name: etf.etfName,
+            ticker: etf.etfCode,
+            theme: etf.theme,
+            price: 10000 + index * 100,
+            change:
+              parseFloat((Math.random() * 5).toFixed(2)) *
+              (Math.random() > 0.5 ? 1 : -1),
+            volume: Math.floor(Math.random() * 100000),
+            returnRate: etf.returnRate,
+          })
+        );
+
+        setEtfData((prev) => {
           const ids = new Set(prev.map((etf) => etf.id));
-          return [...prev, ...pageEtfs.filter(etf => !ids.has(etf.id))];
+          return [...prev, ...pageEtfs.filter((etf) => !ids.has(etf.id))];
         });
 
         if (pageEtfs.length < 20) setHasMore(false);
@@ -116,70 +148,69 @@ export default function Home() {
       }
     };
 
-    fetchEtfPage();
+    fetchEtfPageData();
   }, [page]);
 
   const sortedByChange = allEtfData
-      .filter(etf => typeof etf.change === 'number' && !isNaN(etf.change))
-      .slice();
+    .filter((etf) => typeof etf.change === 'number' && !isNaN(etf.change))
+    .slice();
 
   const topGainers = sortedByChange
-      .sort((a, b) => b.change - a.change)
-      .slice(0, 5);
+    .sort((a, b) => b.change - a.change)
+    .slice(0, 5);
 
   const topLosers = sortedByChange
-      .sort((a, b) => a.change - b.change)
-      .slice(0, 5);
-
+    .sort((a, b) => a.change - b.change)
+    .slice(0, 5);
 
   // 테마별 데이터 분류 및 평균 수익률 계산
-    const topThemes = useMemo(() => {
-      const map: Record<string, { total: number, count: number }> = {};
+  const topThemes = useMemo(() => {
+    const map: Record<string, { total: number; count: number }> = {};
 
-      allEtfData.forEach(etf => {
-        if (!map[etf.theme]) map[etf.theme] = { total: 0, count: 0 };
-        map[etf.theme].total += etf.returnRate;
-        map[etf.theme].count += 1;
-      });
+    allEtfData.forEach((etf) => {
+      if (!map[etf.theme]) map[etf.theme] = { total: 0, count: 0 };
+      map[etf.theme].total += etf.returnRate;
+      map[etf.theme].count += 1;
+    });
 
-      return Object.entries(map)
-          .map(([theme, { total, count }]) => ({
-            id: theme,
-            name: theme,
-            returnRate: total / count,
-            etfCount: count
-          }))
-          .sort((a, b) => b.returnRate - a.returnRate)
-          .slice(0, 4);
-    }, [allEtfData]);
-
+    return Object.entries(map)
+      .map(([theme, { total, count }]) => ({
+        id: theme,
+        name: theme,
+        returnRate: total / count,
+        etfCount: count,
+      }))
+      .sort((a, b) => b.returnRate - a.returnRate)
+      .slice(0, 4);
+  }, [allEtfData]);
 
   //ETF 랭킹 테이블
   const filteredEtfs = useMemo(() => {
     let result = [...etfData];
 
     if (selectedTheme !== 'all') {
-      result = result.filter(e => e.theme === selectedTheme);
+      result = result.filter((e) => e.theme === selectedTheme);
     }
 
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase();
-      result = result.filter(e =>
-          e.name.toLowerCase().includes(query) || e.ticker.toLowerCase().includes(query)
+      result = result.filter(
+        (e) =>
+          e.name.toLowerCase().includes(query) ||
+          e.ticker.toLowerCase().includes(query)
       );
     }
 
-    return result.sort((a, b) => b[sortKey as keyof ETF] - a[sortKey as keyof ETF]);
+    return result.sort(
+      (a, b) => b[sortKey as keyof ETF] - a[sortKey as keyof ETF]
+    );
   }, [etfData, selectedTheme, searchQuery, sortKey]);
-
-
 
   const handleLoadMore = () => {
     if (hasMore) {
-      setPage(prev => prev + 1);
+      setPage((prev) => prev + 1);
     }
   };
-
 
   return (
     <div className="container mx-auto py-6 px-4">
@@ -188,12 +219,18 @@ export default function Home() {
         <div className="grid md:grid-cols-2 gap-8 items-center">
           <div>
             <h1 className="text-4xl font-bold mb-4">폭삭 벌었수다</h1>
-            <p className="text-xl mb-6">최고의 ETF 추천 서비스로 투자 수익을 극대화하세요</p>
+            <p className="text-xl mb-6">
+              최고의 ETF 추천 서비스로 투자 수익을 극대화하세요
+            </p>
             <div className="flex gap-4">
               <Button size="lg" className="bg-green-600 hover:bg-green-700">
                 <Link href="/recommendations">맞춤 ETF 추천받기</Link>
               </Button>
-              <Button size="lg" variant="outline" className="bg-white text-slate-900 border-white hover:bg-slate-100">
+              <Button
+                size="lg"
+                variant="outline"
+                className="bg-white text-slate-900 border-white hover:bg-slate-100"
+              >
                 <Link href="/register">무료 회원가입</Link>
               </Button>
             </div>
@@ -209,15 +246,20 @@ export default function Home() {
               <CardContent>
                 <div className="text-3xl font-bold text-green-400">
                   {allEtfData.length > 0
-                      ? `+${Math.max(...allEtfData.map(etf => etf.returnRate)).toFixed(1)}%`
-                      : '...'}
+                    ? `+${Math.max(
+                        ...allEtfData.map((etf) => etf.returnRate)
+                      ).toFixed(1)}%`
+                    : '...'}
                 </div>
                 <p className="text-sm text-white/70">
                   {allEtfData.length > 0
-                      ? allEtfData.reduce((prev, curr) =>
-                          curr.returnRate === Math.max(...allEtfData.map(e => e.returnRate)) ? curr : prev
+                    ? allEtfData.reduce((prev, curr) =>
+                        curr.returnRate ===
+                        Math.max(...allEtfData.map((e) => e.returnRate))
+                          ? curr
+                          : prev
                       ).name
-                      : ''}
+                    : ''}
                 </p>
               </CardContent>
             </Card>
@@ -232,8 +274,13 @@ export default function Home() {
               <CardContent>
                 <div className="text-3xl font-bold text-green-400">
                   {allEtfData.length > 0
-                      ? `+${(allEtfData.reduce((sum, etf) => sum + etf.returnRate, 0) / allEtfData.length).toFixed(1)}%`
-                      : '...'}
+                    ? `+${(
+                        allEtfData.reduce(
+                          (sum, etf) => sum + etf.returnRate,
+                          0
+                        ) / allEtfData.length
+                      ).toFixed(1)}%`
+                    : '...'}
                 </div>
                 <p className="text-sm text-white/70">전체 ETF 기준</p>
               </CardContent>
@@ -245,8 +292,7 @@ export default function Home() {
               </CardHeader>
               <CardContent>
                 <div>
-               <MarketTickerWidget/>
-
+                  <MarketTickerWidget />
                 </div>
               </CardContent>
             </Card>
@@ -257,26 +303,31 @@ export default function Home() {
       {/* 검색 및 필터 */}
       <div className="mb-8 flex flex-col md:flex-row gap-4">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400"/>
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400" />
           <Input
-              placeholder="ETF 이름 또는 종목코드 검색"
-              className="pl-10"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="ETF 이름 또는 종목코드 검색"
+            className="pl-10"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
           />
         </div>
         <div className="flex gap-2">
-          <Select value={selectedTheme} onValueChange={(val) => setSelectedTheme(val)}>
+          <Select
+            value={selectedTheme}
+            onValueChange={(val) => setSelectedTheme(val)}
+          >
             <SelectTrigger className="w-[180px]">
               <SelectValue placeholder="테마 선택" />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">전체</SelectItem>
-              {Array.from(new Set(allEtfData.map(etf => etf.theme))).map(theme => (
+              {Array.from(new Set(allEtfData.map((etf) => etf.theme))).map(
+                (theme) => (
                   <SelectItem key={theme} value={theme}>
                     {themeNameMap[theme] ?? theme}
                   </SelectItem>
-              ))}
+                )
+              )}
             </SelectContent>
           </Select>
 
@@ -298,12 +349,11 @@ export default function Home() {
         </div>
       </div>
 
-
       {/* 인기 테마 */}
       <div className="mb-8">
         <h2 className="text-2xl font-bold mb-4">인기 테마</h2>
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-        {topThemes.map((theme) => (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+          {topThemes.map((theme) => (
             <Link href={`/themes/${theme.id}`} key={theme.id}>
               <Card className="p-4 bg-white shadow-sm rounded-lg hover:bg-slate-50 transition">
                 <CardHeader className="pb-2">
@@ -316,12 +366,14 @@ export default function Home() {
                   <div className="text-xl font-bold text-green-600">
                     +{theme.returnRate.toFixed(1)}%
                   </div>
-                  <p className="text-sm text-gray-400 mt-1">{theme.etfCount}개 ETF</p>
+                  <p className="text-sm text-gray-400 mt-1">
+                    {theme.etfCount}개 ETF
+                  </p>
                 </CardContent>
               </Card>
             </Link>
-        ))}
-      </div>
+          ))}
+        </div>
       </div>
       {/* 상승/하락 ETF */}
       <div className="mb-8 grid md:grid-cols-2 gap-6">
@@ -336,8 +388,8 @@ export default function Home() {
           <CardContent>
             <div className="space-y-4">
               {topGainers.map((etf) => (
-                    <Link href={`/etf/${etf.id}`} key={etf.id} >
-                      <div  className="flex justify-between items-center p-3 border rounded-lg hover:bg-slate-50 cursor-pointer">
+                <Link href={`/etf/${etf.id}`} key={etf.id}>
+                  <div className="flex justify-between items-center p-3 border rounded-lg hover:bg-slate-50 cursor-pointer">
                     <div>
                       <div className="font-medium">{etf.name}</div>
                       <div className="text-sm text-slate-500">
@@ -345,12 +397,15 @@ export default function Home() {
                       </div>
                     </div>
                     <div className="text-right">
-                      <div className="text-green-600 font-bold">+{etf.change}%</div>
-                      <div className="text-sm">{etf.price.toLocaleString()}원</div>
-                    </div>
+                      <div className="text-green-600 font-bold">
+                        +{etf.change}%
                       </div>
-                      </Link>
-
+                      <div className="text-sm">
+                        {etf.price.toLocaleString()}원
+                      </div>
+                    </div>
+                  </div>
+                </Link>
               ))}
             </div>
           </CardContent>
@@ -376,8 +431,12 @@ export default function Home() {
                       </div>
                     </div>
                     <div className="text-right">
-                      <div className="text-red-600 font-bold">{etf.change}%</div>
-                      <div className="text-sm">{etf.price.toLocaleString()}원</div>
+                      <div className="text-red-600 font-bold">
+                        {etf.change}%
+                      </div>
+                      <div className="text-sm">
+                        {etf.price.toLocaleString()}원
+                      </div>
                     </div>
                   </div>
                 </Link>
@@ -418,14 +477,13 @@ export default function Home() {
 
               <CardFooter className="flex justify-center py-4">
                 {hasMore && (
-                    <Button variant="outline" onClick={handleLoadMore}>
-                      더 보기
-                    </Button>
+                  <Button variant="outline" onClick={handleLoadMore}>
+                    더 보기
+                  </Button>
                 )}
               </CardFooter>
             </Card>
           </TabsContent>
-
         </Tabs>
       </div>
 
@@ -435,14 +493,19 @@ export default function Home() {
           <div className="text-center mb-6">
             <h2 className="text-2xl font-bold mb-2">나만의 맞춤 ETF 추천</h2>
             <p className="text-slate-500 max-w-2xl mx-auto">
-              투자 성향과 목표에 맞는 ETF를 추천받아 더 효율적인 투자를 시작하세요. 회원가입 후 무료로 이용 가능합니다.
+              투자 성향과 목표에 맞는 ETF를 추천받아 더 효율적인 투자를
+              시작하세요. 회원가입 후 무료로 이용 가능합니다.
             </p>
           </div>
           <div className="flex justify-center gap-4">
             <Button size="lg" className="bg-green-600 hover:bg-green-700">
               <Link href="/recommendations">맞춤 ETF 추천받기</Link>
             </Button>
-            <Button size="lg" variant="outline" className="bg-white text-slate-900 border-slate-300 hover:bg-slate-100">
+            <Button
+              size="lg"
+              variant="outline"
+              className="bg-white text-slate-900 border-slate-300 hover:bg-slate-100"
+            >
               <Link href="/register">무료 회원가입</Link>
               {/*{filteredEtfs.map((etf) => (*/}
               {/*    <EtfCard key={etf.id} etf={etf} />*/}
@@ -452,5 +515,5 @@ export default function Home() {
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/front/etf-recommendation/app/profile/[loginId]/actions.ts
+++ b/front/etf-recommendation/app/profile/[loginId]/actions.ts
@@ -42,7 +42,11 @@ export async function updateProfile(
   }
 }
 
-export async function updateProfileImage(formData: FormData) {
+export async function updateProfileImage(formData: FormData): Promise<{
+  success: boolean;
+  message?: string;
+  imageUrl?: string;
+}> {
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
 
@@ -50,26 +54,19 @@ export async function updateProfileImage(formData: FormData) {
     return { success: false, message: '인증 토큰이 없습니다' };
   }
 
-  try {
-    const { data, error } = await uploadProfileImage(formData, accessToken);
+  const { data, error } = await uploadProfileImage(formData, accessToken);
 
-    if (error || !data) {
-      return {
-        success: false,
-        message: error || '이미지 업로드에 실패했습니다',
-      };
-    }
-
-    return {
-      success: true,
-      imageUrl: data.imageUrl,
-    };
-  } catch (error: any) {
+  if (error || !data) {
     return {
       success: false,
-      message: error.message || '이미지 업로드 중 오류가 발생했습니다',
+      message: error || '이미지 업로드에 실패했습니다',
     };
   }
+
+  return {
+    success: true,
+    imageUrl: data.imageUrl,
+  };
 }
 
 export async function changePassword(

--- a/front/etf-recommendation/app/profile/[loginId]/actions.ts
+++ b/front/etf-recommendation/app/profile/[loginId]/actions.ts
@@ -1,101 +1,111 @@
-"use server"
+'use server';
 
-import {cookies} from "next/headers";
-import {revalidatePath} from "next/cache";
-import {authFetch} from "@/app/utils/authFetch";
+import { cookies } from 'next/headers';
+import { revalidatePath } from 'next/cache';
+import {
+  updateUserProfile,
+  uploadProfileImage,
+  changeUserPassword,
+} from '@/lib/api/profile';
 
 // 프로필 업데이트 서버 액션
-export async function updateProfile(loginId: string, nickname: string, isLikePrivate: boolean) {
-    try {
+export async function updateProfile(
+  loginId: string,
+  nickname: string,
+  isLikePrivate: boolean
+) {
+  try {
+    const { data, error } = await updateUserProfile({
+      nickName: nickname,
+      isLikePrivate: isLikePrivate,
+    });
 
-
-        let res = await authFetch("https://localhost:8443/api/v1/users", {
-            method: "PATCH",
-            headers: {
-                "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-                nickName: nickname,
-                isLikePrivate: isLikePrivate
-            }),
-            credentials: "include",
-        });
-
-        if (res.ok) {
-            // 경로 재검증하여 데이터 새로고침
-            revalidatePath(`/profile/${loginId}`);
-            return {
-                success: true,
-                message: "프로필이 업데이트되었습니다",
-                data: await res.json()
-            };
-        } else {
-            const errorText = await res.text();
-            return { success: false, message: `업데이트 실패: ${errorText}` };
-        }
-    } catch (error) {
-        console.error("프로필 업데이트 오류:", error);
-        return { success: false, message: "서버 오류가 발생했습니다" };
+    if (error || !data) {
+      return {
+        success: false,
+        message: error || '프로필 업데이트에 실패했습니다',
+      };
     }
+
+    // 경로 재검증하여 데이터 새로고침
+    revalidatePath(`/profile/${loginId}`);
+    return {
+      success: true,
+      message: '프로필이 업데이트되었습니다',
+      data: data,
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      message: error.message || '프로필 업데이트 중 오류가 발생했습니다',
+    };
+  }
 }
 
 export async function updateProfileImage(formData: FormData) {
-    const cookieStore = await cookies();
-    const accessToken = cookieStore.get('accessToken')?.value;
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
 
-    if (!accessToken) {
-        return { success: false, message: "인증 토큰이 없습니다" };
+  if (!accessToken) {
+    return { success: false, message: '인증 토큰이 없습니다' };
+  }
+
+  try {
+    const { data, error } = await uploadProfileImage(formData, accessToken);
+
+    if (error || !data) {
+      return {
+        success: false,
+        message: error || '이미지 업로드에 실패했습니다',
+      };
     }
 
-    const res = await fetch("https://localhost:8443/api/v1/users/image", {
-        method: "PATCH",
-        headers: {
-            Authorization: `Bearer ${accessToken}`,
-        },
-        body: formData,
-    });
-
-    if (res.ok) {
-        const data = await res.json();
-        return { success: true, imageUrl: data.imageUrl };
-    } else {
-        const error = await res.text();
-        return { success: false, message: error };
-    }
+    return {
+      success: true,
+      imageUrl: data.imageUrl,
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      message: error.message || '이미지 업로드 중 오류가 발생했습니다',
+    };
+  }
 }
 
 export async function changePassword(
-    existingPassword: string,
-    newPassword: string,
-    confirmNewPassword: string
+  existingPassword: string,
+  newPassword: string,
+  confirmNewPassword: string
 ) {
-    const cookieStore = await cookies();
-    const accessToken = cookieStore.get("accessToken")?.value;
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
 
-    if (!accessToken) {
-        return { success: false, message: "인증 토큰이 없습니다." };
-    }
+  if (!accessToken) {
+    return { success: false, message: '인증 토큰이 없습니다.' };
+  }
 
-    const res = await fetch(
-        "https://localhost:8443/api/v1/users/me/password",
-        {
-            method: "PATCH",
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${accessToken}`,
-            },
-            body: JSON.stringify({
-                existingPassword,
-                newPassword,
-                confirmNewPassword,
-            }),
-        }
+  try {
+    const { error } = await changeUserPassword(
+      {
+        existingPassword,
+        newPassword,
+        confirmNewPassword,
+      },
+      accessToken
     );
 
-    if (res.ok) {
-        return { success: true };
-    } else {
-        const msg = await res.text();
-        return { success: false, message: msg };
+    if (error) {
+      return {
+        success: false,
+        message: error,
+      };
     }
+
+    return { success: true };
+  } catch (error: any) {
+    return {
+      success: false,
+      message: error.message || '비밀번호 변경 중 오류가 발생했습니다',
+    };
+  }
 }

--- a/front/etf-recommendation/app/profile/[loginId]/page.tsx
+++ b/front/etf-recommendation/app/profile/[loginId]/page.tsx
@@ -1,42 +1,37 @@
 import ProfileClient from './profile-client';
 import { cookies } from 'next/headers';
-import {redirect} from "next/navigation";
+import { redirect } from 'next/navigation';
+import { fetchUserProfile } from '@/lib/api/auth';
 
 export default async function ProfilePage({
-                                              params,
-                                          }: {
-    params: Promise<{ loginId: string }>
+  params,
+}: {
+  params: Promise<{ loginId: string }>;
 }) {
-    // 라우트 파라미터에서 loginId 추출
-    const { loginId } = await params;
+  // 라우트 파라미터에서 loginId 추출
+  const { loginId } = await params;
 
-    // 서버에서 쿠키 가져오기
-    const cookieStore = await cookies();
-    const accessToken = cookieStore.get('accessToken')?.value;
-    if (!loginId || !accessToken) {
-        redirect('/login');
+  // 서버에서 쿠키 가져오기
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+  if (!loginId || !accessToken) {
+    redirect('/login');
+  }
+
+  // 서버에서 초기 프로필 데이터 가져오기
+  let initialProfileData = null;
+  if (accessToken) {
+    const { data, error } = await fetchUserProfile(loginId, accessToken);
+
+    if (error || !data) {
+      console.error('프로필 데이터 불러오기 실패:', error);
+    } else {
+      initialProfileData = data;
     }
-    // 서버에서 초기 프로필 데이터 가져오기
-    let initialProfileData = null;
-    if (accessToken) {
-        try {
-            const response = await fetch(`https://localhost:8443/api/v1/users/${loginId}`, {
-                headers: {
-                    'Authorization': `Bearer ${accessToken}`,
-                    'Content-Type': 'application/json'
-                },
-            });
+  }
 
-            if (response.ok) {
-                initialProfileData = await response.json();
-            } else {
-                console.error(`서버 오류: ${response.status}`);
-            }
-        } catch (error) {
-            console.error("서버에서 프로필 데이터 로드 오류:", error);
-        }
-    }
-
-    // 클라이언트 컴포넌트에 데이터 전달
-    return <ProfileClient initialProfileData={initialProfileData} loginId={loginId} />;
+  // 클라이언트 컴포넌트에 데이터 전달
+  return (
+    <ProfileClient initialProfileData={initialProfileData} loginId={loginId} />
+  );
 }

--- a/front/etf-recommendation/app/profile/[loginId]/profile-client.tsx
+++ b/front/etf-recommendation/app/profile/[loginId]/profile-client.tsx
@@ -23,12 +23,13 @@ import LogoutButton from '@/components/ui/LogoutButton';
 import { getSubscribedEtfIds } from '@/app/etf/[id]/action';
 import Link from 'next/link';
 import { fetchEtfDetail } from '@/lib/api/etf';
+import { UserDetailResponse } from '@/lib/api/auth';
 
 export default function ProfileClient({
   initialProfileData,
   loginId,
 }: {
-  initialProfileData: any | null;
+  initialProfileData: UserDetailResponse | null;
   loginId: string;
 }) {
   // 상태 관리
@@ -93,7 +94,7 @@ export default function ProfileClient({
 
     const result = await updateProfileImage(formData); // 서버 액션 호출
     if (result.success) {
-      setAvatarSrc(result.imageUrl);
+      setAvatarSrc(result.imageUrl!);
       alert('프로필 사진이 성공적으로 업데이트되었습니다.');
     } else {
       alert('업로드 실패: ' + result.message);

--- a/front/etf-recommendation/app/profile/[loginId]/profile-client.tsx
+++ b/front/etf-recommendation/app/profile/[loginId]/profile-client.tsx
@@ -1,369 +1,413 @@
-"use client"
+'use client';
 
-import React, {useState, useRef, useEffect} from "react";
-import { Button } from "@/components/ui/button";
-import {updateProfile,updateProfileImage, changePassword} from "./actions";
-import {Card, CardContent, CardHeader} from "@/components/ui/card"
-import {Input} from "@/components/ui/input"
-import {Label} from "@/components/ui/label"
-import {Tabs, TabsContent, TabsList, TabsTrigger} from "@/components/ui/tabs"
-import {Avatar, AvatarFallback, AvatarImage} from "@/components/ui/avatar"
-import {Switch} from "@/components/ui/switch"
+import React, { useState, useRef, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { updateProfile, updateProfileImage, changePassword } from './actions';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Switch } from '@/components/ui/switch';
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
-} from "@/components/ui/dialog"
-import {Camera, Pencil, Star} from "lucide-react"
-import LogoutButton from "@/components/ui/LogoutButton";
-import {getSubscribedEtfIds} from "@/app/etf/[id]/action";
-import Link from "next/link";
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Camera, Pencil, Star } from 'lucide-react';
+import LogoutButton from '@/components/ui/LogoutButton';
+import { getSubscribedEtfIds } from '@/app/etf/[id]/action';
+import Link from 'next/link';
+import { fetchEtfDetail } from '@/lib/api/etf';
 
 export default function ProfileClient({
-                                          initialProfileData,
-                                          loginId,
-                                      }: {
-    initialProfileData: any | null;
-    loginId: string;
-})
-{
-    // 상태 관리
-    const [createdAt] = useState(initialProfileData?.createdAt || "");
-    const [nickname, setNickname] = useState(initialProfileData?.nickName || "");
-    const [userId, setUserId] = useState(initialProfileData?.loginId || "");
-    const [isPublicPortfolio, setIsPublicPortfolio] = useState(!initialProfileData?.isLikePrivate);
-    const [avatarSrc, setAvatarSrc] = useState(initialProfileData?.imageUrl || "/placeholder.svg");
-    const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState(false);
-    const [currentPassword, setCurrentPassword] = useState("");
-    const [newPassword, setNewPassword] = useState("");
-    const [confirmPassword, setConfirmPassword] = useState("");
-    const fileInputRef = useRef<HTMLInputElement>(null);
-    const [isLoading, setIsLoading] = useState(false);
-    const [message, setMessage] = useState("");
-    const [subscribedEtfIds, setSubscribedEtfIds] = useState<number[]>([]); // 구독한 ETF ID 목록
-    const [etfDetails, setEtfDetails] = useState<any[]>([]);
+  initialProfileData,
+  loginId,
+}: {
+  initialProfileData: any | null;
+  loginId: string;
+}) {
+  // 상태 관리
+  const [createdAt] = useState(initialProfileData?.createdAt || '');
+  const [nickname, setNickname] = useState(initialProfileData?.nickName || '');
+  const [userId, setUserId] = useState(initialProfileData?.loginId || '');
+  const [isPublicPortfolio, setIsPublicPortfolio] = useState(
+    !initialProfileData?.isLikePrivate
+  );
+  const [avatarSrc, setAvatarSrc] = useState(
+    initialProfileData?.imageUrl || '/placeholder.svg'
+  );
+  const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [message, setMessage] = useState('');
+  const [subscribedEtfIds, setSubscribedEtfIds] = useState<number[]>([]); // 구독한 ETF ID 목록
+  const [etfDetails, setEtfDetails] = useState<any[]>([]);
 
-    useEffect(() => {
-        const fetchSubscribedEtfs = async () => {
-            const subscribedIds = await getSubscribedEtfIds(); // 구독한 ETF ID 목록을 가져옵니다.
-            setSubscribedEtfIds(subscribedIds); // 구독한 ETF ID 목록 상태에 저장
+  useEffect(() => {
+    const fetchSubscribedEtfs = async () => {
+      const subscribedIds = await getSubscribedEtfIds(); // 구독한 ETF ID 목록을 가져옵니다.
+      setSubscribedEtfIds(subscribedIds); // 구독한 ETF ID 목록 상태에 저장
 
-            // 구독한 ETF의 상세 정보를 가져오는 로직 (예: ETF 이름, 티커 등)
-            if (subscribedIds.length > 0) {
-                const etfs = await Promise.all(subscribedIds.map(async (id) => {
-                    const res = await fetch(`https://localhost:8443/api/v1/etfs/${id}`);
-                    if (res.ok) {
-                        const data = await res.json();
-                        return { id: data.etfId, name: data.etfName, ticker: data.etfCode };
-                    }
-                    return null;
-                }));
-                setEtfDetails(etfs.filter(etf => etf !== null)); // 유효한 ETF들만 필터링하여 세부 정보 저장
+      // 구독한 ETF의 상세 정보를 가져오는 로직 (예: ETF 이름, 티커 등)
+      if (subscribedIds.length > 0) {
+        const etfs = await Promise.all(
+          subscribedIds.map(async (id) => {
+            const { data, error } = await fetchEtfDetail(id);
+            if (error || !data) {
+              console.error(`ETF ID ${id} 불러오기 실패:`, error);
+              return null;
             }
-        };
+            return {
+              id: data.etfId,
+              name: data.etfName,
+              ticker: data.etfCode,
+            };
+          })
+        );
+        setEtfDetails(etfs.filter((etf) => etf !== null)); // 유효한 ETF들만 필터링하여 세부 정보 저장
+      }
+    };
 
-        fetchSubscribedEtfs(); // 데이터 로드
-    }, []);
+    fetchSubscribedEtfs(); // 데이터 로드
+  }, []);
 
-    // 프로필 사진 변경 처리
-    const handleAvatarClick = () => {
-        fileInputRef.current?.click()
+  // 프로필 사진 변경 처리
+  const handleAvatarClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const formData = new FormData();
+    formData.append('images', file);
+
+    const result = await updateProfileImage(formData); // 서버 액션 호출
+    if (result.success) {
+      setAvatarSrc(result.imageUrl);
+      alert('프로필 사진이 성공적으로 업데이트되었습니다.');
+    } else {
+      alert('업로드 실패: ' + result.message);
+    }
+  };
+
+  // 정보 수정 처리
+  const handleProfileUpdate = async () => {
+    if (
+      nickname === initialProfileData?.nickName &&
+      isPublicPortfolio === !initialProfileData?.isLikePrivate
+    ) {
+      setMessage('업데이트할 내용이 없습니다.');
+      return;
+    }
+    try {
+      setIsLoading(true);
+      setMessage('');
+
+      const result = await updateProfile(loginId, nickname, !isPublicPortfolio);
+
+      if (result.success && result.data) {
+        setMessage('프로필 정보가 업데이트되었습니다.');
+        setNickname(result.data.nickName || '');
+        setIsPublicPortfolio(!result.data.isLikePrivate);
+      } else {
+        setMessage(result.message || '업데이트 실패');
+      }
+    } catch (err) {
+      console.error('업데이트 처리 오류:', err);
+      setMessage('서버 오류 발생');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 비밀번호 변경 처리
+  const handlePasswordChange = async () => {
+    if (!currentPassword) {
+      alert('현재 비밀번호를 입력해주세요.');
+      return;
+    }
+    if (!newPassword) {
+      alert('새 비밀번호를 입력해주세요.');
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      alert('새 비밀번호와 확인 비밀번호가 일치하지 않습니다.');
+      return;
     }
 
-    const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        if (!file) return;
+    const result = await changePassword(
+      currentPassword,
+      newPassword,
+      confirmPassword
+    );
 
-        const formData = new FormData();
-        formData.append("images", file);
+    if (result.success) {
+      alert('비밀번호가 성공적으로 변경되었습니다.');
+      setIsPasswordDialogOpen(false);
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+    } else {
+      alert('비밀번호 변경 실패: ' + result.message);
+    }
+  };
 
-        const result = await updateProfileImage(formData); // 서버 액션 호출
-        if (result.success) {
-            setAvatarSrc(result.imageUrl);
-            alert("프로필 사진이 성공적으로 업데이트되었습니다.");
-        } else {
-            alert("업로드 실패: " + result.message);
-        }
-    };
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">내 프로필</h1>
+        <p className="text-slate-500">계정 정보 및 투자 내역을 관리하세요.</p>
+      </div>
 
-
-    // 정보 수정 처리
-    const handleProfileUpdate = async () => {
-        if (
-            nickname === initialProfileData?.nickName &&
-            isPublicPortfolio === !initialProfileData?.isLikePrivate
-        ) {
-            setMessage("업데이트할 내용이 없습니다.");
-            return;
-        }
-        try {
-            setIsLoading(true);
-            setMessage("");
-
-            const result = await updateProfile(
-                loginId,
-                nickname,
-                !isPublicPortfolio
-            );
-
-            if (result.success && result.data) {
-                setMessage("프로필 정보가 업데이트되었습니다.");
-                setNickname(result.data.nickName || "");
-                setIsPublicPortfolio(!result.data.isLikePrivate);
-            } else {
-                setMessage(result.message || "업데이트 실패");
-            }
-        } catch (err) {
-            console.error("업데이트 처리 오류:", err);
-            setMessage("서버 오류 발생");
-        } finally {
-            setIsLoading(false);
-        }
-    };
-
-
-    // 비밀번호 변경 처리
-    const handlePasswordChange = async () => {
-        if (!currentPassword) {
-            alert("현재 비밀번호를 입력해주세요.");
-            return;
-        }
-        if (!newPassword) {
-            alert("새 비밀번호를 입력해주세요.");
-            return;
-        }
-        if (newPassword !== confirmPassword) {
-            alert("새 비밀번호와 확인 비밀번호가 일치하지 않습니다.");
-            return;
-        }
-
-        const result = await changePassword(
-            currentPassword,
-            newPassword,
-            confirmPassword
-        );
-
-        if (result.success) {
-            alert("비밀번호가 성공적으로 변경되었습니다.");
-            setIsPasswordDialogOpen(false);
-            setCurrentPassword("");
-            setNewPassword("");
-            setConfirmPassword("");
-        } else {
-            alert("비밀번호 변경 실패: " + result.message);
-        }
-    };
-
-
-    return (
-        <div className="container mx-auto py-8 px-4">
-            <div className="mb-8">
-                <h1 className="text-3xl font-bold mb-2">내 프로필</h1>
-                <p className="text-slate-500">계정 정보 및 투자 내역을 관리하세요.</p>
+      <div className="grid gap-6 md:grid-cols-3">
+        <Card className="md:col-span-1">
+          <CardContent className="pt-6">
+            <div className="flex flex-col items-center space-y-4">
+              {/* 프로필 사진 업로드 기능 */}
+              <div className="relative group">
+                <Avatar
+                  className="h-24 w-24 cursor-pointer group-hover:opacity-80 transition-opacity"
+                  onClick={handleAvatarClick}
+                >
+                  <AvatarImage
+                    src={avatarSrc || '/placeholder.svg'}
+                    alt="프로필 이미지"
+                    className="h-full w-full object-cover object-center"
+                  />
+                  <AvatarFallback>사용자</AvatarFallback>
+                </Avatar>
+                <div
+                  className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                  onClick={handleAvatarClick}
+                >
+                  <div className="bg-black bg-opacity-50 rounded-full p-2">
+                    <Camera className="h-6 w-6 text-white" />
+                  </div>
+                </div>
+                <input
+                  type="file"
+                  ref={fileInputRef}
+                  className="hidden"
+                  accept="image/*"
+                  onChange={handleFileChange}
+                />
+              </div>
+              <div className="text-center">
+                <div className="flex items-center justify-center gap-2">
+                  <h2 className="text-xl font-bold">{nickname}</h2>
+                  <button
+                    className="text-slate-500 hover:text-slate-700"
+                    onClick={() =>
+                      document.getElementById('nickname-input')?.focus()
+                    }
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </button>
+                </div>
+                <p className="text-sm text-slate-500">@{userId}</p>{' '}
+                {/* 이메일 대신 아이디 표시 */}
+              </div>
+              <div className="w-full pt-4">
+                <div className="flex justify-between py-2 border-b"></div>
+                <div className="flex justify-between py-2 border-b">
+                  <span className="text-slate-500">가입 일시</span>
+                  <span>
+                    {createdAt
+                      ? new Date(createdAt).toLocaleString('ko-KR', {
+                          year: 'numeric',
+                          month: '2-digit',
+                          day: '2-digit',
+                        })
+                      : '-'}
+                  </span>
+                </div>
+                <div className="flex justify-between py-2 border-b">
+                  <span className="text-slate-500">투자 성향</span>
+                  <span>성장형</span>
+                </div>
+                <div className="flex justify-between py-2 border-b">
+                  <span className="text-slate-500">관심 테마</span>
+                  <span>기술, 에너지</span>
+                </div>
+              </div>
             </div>
+          </CardContent>
+        </Card>
 
-            <div className="grid gap-6 md:grid-cols-3">
-                <Card className="md:col-span-1">
-                    <CardContent className="pt-6">
-                        <div className="flex flex-col items-center space-y-4">
-                            {/* 프로필 사진 업로드 기능 */}
-                            <div className="relative group">
-                                <Avatar
-                                    className="h-24 w-24 cursor-pointer group-hover:opacity-80 transition-opacity"
-                                    onClick={handleAvatarClick}
-                                >
-                                    <AvatarImage src={avatarSrc || "/placeholder.svg"} alt="프로필 이미지"
-                                                 className="h-full w-full object-cover object-center"
-                                    />
-                                    <AvatarFallback>사용자</AvatarFallback>
-                                </Avatar>
-                                <div
-                                    className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
-                                    onClick={handleAvatarClick}
-                                >
-                                    <div className="bg-black bg-opacity-50 rounded-full p-2">
-                                        <Camera className="h-6 w-6 text-white"/>
-                                    </div>
-                                </div>
-                                <input type="file" ref={fileInputRef} className="hidden" accept="image/*"
-                                       onChange={handleFileChange}/>
+        <Card className="md:col-span-2">
+          <CardHeader>
+            <Tabs defaultValue="account">
+              <TabsList className="grid w-full grid-cols-3">
+                <TabsTrigger value="account">계정 정보</TabsTrigger>
+                <TabsTrigger value="comments">댓글 목록</TabsTrigger>
+                <TabsTrigger value="subscribe">구독 내역</TabsTrigger>
+              </TabsList>
+              <TabsContent value="subscribe" className="space-y-4 mt-4">
+                <div className="mt-4">
+                  <div className="bg-white p-4 rounded-lg shadow-lg">
+                    {subscribedEtfIds.length === 0 ? (
+                      <p className="text-gray-600">구독한 ETF가 없습니다.</p>
+                    ) : (
+                      <ul className="space-y-4">
+                        {etfDetails.map((etf, index) => (
+                          <li
+                            key={index}
+                            className="flex items-center justify-between bg-gray-100 p-2 rounded-lg hover:bg-gray-200 transition duration-200"
+                          >
+                            <div>
+                              <Link
+                                href={`/etf/${etf.id}`}
+                                className="text-xl font-semibold text-gray-800"
+                              >
+                                {etf.name}
+                                <p className="text-gray-600">{etf.ticker}</p>
+                              </Link>
                             </div>
-                            <div className="text-center">
-                                <div className="flex items-center justify-center gap-2">
-                                    <h2 className="text-xl font-bold">{nickname}</h2>
-                                    <button
-                                        className="text-slate-500 hover:text-slate-700"
-                                        onClick={() => document.getElementById("nickname-input")?.focus()}
-                                    >
-                                        <Pencil className="h-4 w-4"/>
-                                    </button>
-                                </div>
-                                <p className="text-sm text-slate-500">@{userId}</p> {/* 이메일 대신 아이디 표시 */}
+                            <div className="text-yellow-500">
+                              <Star className="h-6 w-6" />
                             </div>
-                            <div className="w-full pt-4">
-                                <div className="flex justify-between py-2 border-b">
-                                </div>
-                                <div className="flex justify-between py-2 border-b">
-                                    <span className="text-slate-500">가입 일시</span>
-                                    <span>
-    {createdAt
-        ? new Date(createdAt).toLocaleString("ko-KR", {
-            year: "numeric",
-            month: "2-digit",
-            day: "2-digit"
-        })
-        : "-"}
-  </span>
-                                </div>
-                                <div className="flex justify-between py-2 border-b">
-                                    <span className="text-slate-500">투자 성향</span>
-                                    <span>성장형</span>
-                                </div>
-                                <div className="flex justify-between py-2 border-b">
-                                    <span className="text-slate-500">관심 테마</span>
-                                    <span>기술, 에너지</span>
-                                </div>
-                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                </div>
+              </TabsContent>
+              <TabsContent value="account" className="space-y-4 mt-4">
+                <div className="space-y-2">
+                  <Label htmlFor="nickname-input">닉네임</Label>
+                  <Input
+                    id="nickname-input"
+                    value={nickname}
+                    onChange={(e) => setNickname(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="user-id">아이디</Label>{' '}
+                  {/* 이메일 대신 아이디로 변경 */}
+                  <Input
+                    id="user-id"
+                    value={userId}
+                    onChange={(e) => setUserId(e.target.value)}
+                    disabled
+                  />
+                  <p className="text-xs text-slate-500">
+                    아이디는 변경할 수 없습니다.
+                  </p>
+                </div>
+
+                {/* ETF 내역 공개 여부 설정 */}
+                <div className="flex items-center justify-between space-x-2 pt-2">
+                  <Label htmlFor="portfolio-public">ETF , 댓글 내역 공개</Label>
+                  <Switch
+                    id="portfolio-public"
+                    checked={isPublicPortfolio}
+                    onCheckedChange={setIsPublicPortfolio}
+                  />
+                </div>
+                <p className="text-xs text-slate-500">
+                  {isPublicPortfolio
+                    ? '다른 사용자가 내 ETF , 댓글 내역을 볼 수 있습니다.'
+                    : '내 ETF , 댓글 내역은 비공개로 설정되어 있습니다.'}
+                </p>
+
+                <Button onClick={handleProfileUpdate} disabled={isLoading}>
+                  정보 수정
+                </Button>
+
+                {message && (
+                  <p
+                    className={`mt-2 text-sm ${
+                      message.includes('실패')
+                        ? 'text-red-500'
+                        : 'text-green-500'
+                    }`}
+                  >
+                    {message}
+                  </p>
+                )}
+
+                {/* 비밀번호 변경 다이얼로그 */}
+                <div className="pt-4 border-t mt-4">
+                  <h3 className="text-lg font-medium mb-2">비밀번호 변경</h3>
+                  <Dialog
+                    open={isPasswordDialogOpen}
+                    onOpenChange={setIsPasswordDialogOpen}
+                  >
+                    <DialogTrigger asChild>
+                      <Button variant="outline">비밀번호 변경</Button>
+                    </DialogTrigger>
+                    <DialogContent className="sm:max-w-[425px]">
+                      <DialogHeader>
+                        <DialogTitle>비밀번호 변경</DialogTitle>
+                        <DialogDescription>
+                          현재 비밀번호를 입력하고 새 비밀번호를 설정하세요.
+                        </DialogDescription>
+                      </DialogHeader>
+                      <div className="grid gap-4 py-4">
+                        <div className="grid gap-2">
+                          <Label htmlFor="current-password">
+                            현재 비밀번호
+                          </Label>
+                          <Input
+                            id="current-password"
+                            type="password"
+                            value={currentPassword}
+                            onChange={(e) => setCurrentPassword(e.target.value)}
+                          />
                         </div>
-                    </CardContent>
-                </Card>
-
-                <Card className="md:col-span-2">
-                    <CardHeader>
-                        <Tabs defaultValue="account">
-                            <TabsList className="grid w-full grid-cols-3">
-                                <TabsTrigger value="account">계정 정보</TabsTrigger>
-                                <TabsTrigger value="comments">댓글 목록</TabsTrigger>
-                                <TabsTrigger value="subscribe">구독 내역</TabsTrigger>
-                            </TabsList>
-                            <TabsContent value="subscribe" className="space-y-4 mt-4">
-                            <div className="mt-4">
-                                <div className="bg-white p-4 rounded-lg shadow-lg">
-                                    {subscribedEtfIds.length === 0 ? (
-                                        <p className="text-gray-600">구독한 ETF가 없습니다.</p>
-                                    ) : (
-                                        <ul className="space-y-4">
-                                            {etfDetails.map((etf, index) => (
-                                                <li key={index} className="flex items-center justify-between bg-gray-100 p-2 rounded-lg hover:bg-gray-200 transition duration-200">
-                                                    <div>
-                                                        <Link href={`/etf/${etf.id}`} className="text-xl font-semibold text-gray-800">
-                                                            {etf.name}
-                                                            <p className="text-gray-600">{etf.ticker}</p>
-                                                        </Link>
-                                                    </div>
-                                                    <div className="text-yellow-500">
-                                                        <Star className="h-6 w-6" />
-                                                    </div>
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    )}
-                                </div>
-                            </div>
-                            </TabsContent>
-                            <TabsContent value="account" className="space-y-4 mt-4">
-                                <div className="space-y-2">
-                                    <Label htmlFor="nickname-input">닉네임</Label>
-                                    <Input id="nickname-input" value={nickname}
-                                           onChange={(e) => setNickname(e.target.value)}/>
-                                </div>
-                                <div className="space-y-2">
-                                    <Label htmlFor="user-id">아이디</Label> {/* 이메일 대신 아이디로 변경 */}
-                                    <Input id="user-id" value={userId} onChange={(e) => setUserId(e.target.value)}
-                                           disabled/>
-                                    <p className="text-xs text-slate-500">아이디는 변경할 수 없습니다.</p>
-                                </div>
-
-                                {/* ETF 내역 공개 여부 설정 */}
-                                <div className="flex items-center justify-between space-x-2 pt-2">
-                                    <Label htmlFor="portfolio-public">ETF , 댓글 내역 공개</Label>
-                                    <Switch id="portfolio-public" checked={isPublicPortfolio}
-                                            onCheckedChange={setIsPublicPortfolio}/>
-                                </div>
-                                <p className="text-xs text-slate-500">
-                                    {isPublicPortfolio
-                                        ? "다른 사용자가 내 ETF , 댓글 내역을 볼 수 있습니다."
-                                        : "내 ETF , 댓글 내역은 비공개로 설정되어 있습니다."}
-                                </p>
-
-                                <Button onClick={handleProfileUpdate} disabled={isLoading}>
-                                    정보 수정
-                                </Button>
-
-                                {message && (
-                                    <p
-                                        className={`mt-2 text-sm ${
-                                            message.includes("실패") ? "text-red-500" : "text-green-500"
-                                        }`}
-                                    >
-                                        {message}
-                                    </p>
-                                )}
-
-                                {/* 비밀번호 변경 다이얼로그 */}
-                                <div className="pt-4 border-t mt-4">
-                                    <h3 className="text-lg font-medium mb-2">비밀번호 변경</h3>
-                                    <Dialog open={isPasswordDialogOpen} onOpenChange={setIsPasswordDialogOpen}>
-                                        <DialogTrigger asChild>
-                                            <Button variant="outline">비밀번호 변경</Button>
-                                        </DialogTrigger>
-                                        <DialogContent className="sm:max-w-[425px]">
-                                            <DialogHeader>
-                                                <DialogTitle>비밀번호 변경</DialogTitle>
-                                                <DialogDescription>현재 비밀번호를 입력하고 새 비밀번호를 설정하세요.</DialogDescription>
-                                            </DialogHeader>
-                                            <div className="grid gap-4 py-4">
-                                                <div className="grid gap-2">
-                                                    <Label htmlFor="current-password">현재 비밀번호</Label>
-                                                    <Input
-                                                        id="current-password"
-                                                        type="password"
-                                                        value={currentPassword}
-                                                        onChange={(e) => setCurrentPassword(e.target.value)}
-                                                    />
-                                                </div>
-                                                <div className="grid gap-2">
-                                                    <Label htmlFor="new-password">새 비밀번호</Label>
-                                                    <Input
-                                                        id="new-password"
-                                                        type="password"
-                                                        value={newPassword}
-                                                        onChange={(e) => setNewPassword(e.target.value)}
-                                                    />
-                                                </div>
-                                                <div className="grid gap-2">
-                                                    <Label htmlFor="confirm-password">비밀번호 확인</Label>
-                                                    <Input
-                                                        id="confirm-password"
-                                                        type="password"
-                                                        value={confirmPassword}
-                                                        onChange={(e) => setConfirmPassword(e.target.value)}
-                                                    />
-                                                </div>
-                                            </div>
-                                            <DialogFooter>
-                                                <Button variant="outline"
-                                                        onClick={() => setIsPasswordDialogOpen(false)}>
-                                                    취소
-                                                </Button>
-                                                <Button onClick={handlePasswordChange}>변경하기</Button>
-                                            </DialogFooter>
-                                        </DialogContent>
-                                    </Dialog>
-                                </div>
-                                {/* 로그아웃 버튼 */}
-                                <div className="pt-4 border-t mt-4">
-                                    <LogoutButton />
-                                </div>
-                            </TabsContent>
-                        </Tabs>
-                    </CardHeader>
-                </Card>
-            </div>
-        </div>
-    )
+                        <div className="grid gap-2">
+                          <Label htmlFor="new-password">새 비밀번호</Label>
+                          <Input
+                            id="new-password"
+                            type="password"
+                            value={newPassword}
+                            onChange={(e) => setNewPassword(e.target.value)}
+                          />
+                        </div>
+                        <div className="grid gap-2">
+                          <Label htmlFor="confirm-password">
+                            비밀번호 확인
+                          </Label>
+                          <Input
+                            id="confirm-password"
+                            type="password"
+                            value={confirmPassword}
+                            onChange={(e) => setConfirmPassword(e.target.value)}
+                          />
+                        </div>
+                      </div>
+                      <DialogFooter>
+                        <Button
+                          variant="outline"
+                          onClick={() => setIsPasswordDialogOpen(false)}
+                        >
+                          취소
+                        </Button>
+                        <Button onClick={handlePasswordChange}>변경하기</Button>
+                      </DialogFooter>
+                    </DialogContent>
+                  </Dialog>
+                </div>
+                {/* 로그아웃 버튼 */}
+                <div className="pt-4 border-t mt-4">
+                  <LogoutButton />
+                </div>
+              </TabsContent>
+            </Tabs>
+          </CardHeader>
+        </Card>
+      </div>
+    </div>
+  );
 }

--- a/front/etf-recommendation/app/register/page.tsx
+++ b/front/etf-recommendation/app/register/page.tsx
@@ -1,116 +1,122 @@
-"use client"
-import { useState } from "react"
-import { useRouter } from "next/navigation"
-import Link from "next/link"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Checkbox } from "@/components/ui/checkbox"
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { register } from '@/lib/api/auth';
 
 export default function RegisterPage() {
-  const [loginId, setLoginId] = useState("")
-  const [nickname, setNickname] = useState("")
-  const [password, setPassword] = useState("")
-  const [isLikePrivate, setIsLikePrivate] = useState(false)
-  const router = useRouter()
+  const [loginId, setLoginId] = useState('');
+  const [nickname, setNickname] = useState('');
+  const [password, setPassword] = useState('');
+  const [isLikePrivate, setIsLikePrivate] = useState(false);
+  const router = useRouter();
 
   const handleRegister = async () => {
     try {
-      const res = await fetch("https://localhost:8443/api/v1/join", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          loginId,
-          password: password,  // 암호화된 비밀번호
-          nickName: nickname,
-          isLikePrivate
-        }),
+      const { data, error } = await register({
+        loginId,
+        password,
+        nickname,
+        isLikePrivate,
       });
 
-      if (res.ok) {
-        alert("회원가입 성공!");
-        router.push("/login");
-      } else {
-        const errorData = await res.json();
-        alert("회원가입 실패: " + errorData.message);
+      if (error || !data) {
+        alert('회원가입 실패: ' + (error || '알 수 없는 오류'));
+        return;
       }
+
+      alert('회원가입 성공!');
+      router.push('/login');
     } catch (err) {
-      console.error("Error:", err);
-      alert("서버와 연결 실패");
+      console.error('Error:', err);
+      alert('서버와 연결 실패');
     }
   };
 
   return (
-      <div className="container mx-auto flex items-center justify-center min-h-screen py-8 px-4">
-        <Card className="w-full max-w-md">
-          <CardHeader>
-            <CardTitle className="text-2xl">회원가입</CardTitle>
-            <CardDescription>계정을 만들고 맞춤형 ETF 추천을 받아보세요.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="id">아이디</Label>
-              <Input
-                  id="id"
-                  type="text"
-                  placeholder="아이디를 입력하세요"
-                  value={loginId}
-                  onChange={(e) => setLoginId(e.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="nickname">닉네임</Label>
-              <Input
-                  id="nickname"
-                  type="text"
-                  placeholder="닉네임을 입력하세요"
-                  value={nickname}
-                  onChange={(e) => setNickname(e.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="password">비밀번호</Label>
-              <Input
-                  id="password"
-                  type="password"
-                  placeholder="비밀번호를 입력하세요"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-              />
-            </div>
-            <div className="flex items-center space-x-2">
-              <input
-                  type="checkbox"
-                  id="isLikePrivate"
-                  name="isLikePrivate"
-                  className="h-4 w-4"
-                  checked={isLikePrivate}
-                  onChange={(e) => setIsLikePrivate(e.target.checked)}
-              />
-              <label htmlFor="isLikePrivate" className="text-sm">
-                내 ETF 목록을 비공개로 설정합니다
-              </label>
-            </div>
-            <div className="flex items-center space-x-2">
-              <Checkbox id="terms" />
-              <Label htmlFor="terms" className="text-sm">
-                이용약관 및 개인정보 처리방침에 동의합니다
-              </Label>
-            </div>
-          </CardContent>
-          <CardFooter className="flex flex-col space-y-4">
-            <Button className="w-full" onClick={handleRegister}>
-              회원가입
-            </Button>
-            <div className="text-center text-sm">
-              이미 계정이 있으신가요?{" "}
-              <Link href="/login" className="text-blue-600 hover:underline">
-                로그인
-              </Link>
-            </div>
-          </CardFooter>
-        </Card>
-      </div>
-  )
+    <div className="container mx-auto flex items-center justify-center min-h-screen py-8 px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle className="text-2xl">회원가입</CardTitle>
+          <CardDescription>
+            계정을 만들고 맞춤형 ETF 추천을 받아보세요.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="id">아이디</Label>
+            <Input
+              id="id"
+              type="text"
+              placeholder="아이디를 입력하세요"
+              value={loginId}
+              onChange={(e) => setLoginId(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="nickname">닉네임</Label>
+            <Input
+              id="nickname"
+              type="text"
+              placeholder="닉네임을 입력하세요"
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">비밀번호</Label>
+            <Input
+              id="password"
+              type="password"
+              placeholder="비밀번호를 입력하세요"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+          <div className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              id="isLikePrivate"
+              name="isLikePrivate"
+              className="h-4 w-4"
+              checked={isLikePrivate}
+              onChange={(e) => setIsLikePrivate(e.target.checked)}
+            />
+            <label htmlFor="isLikePrivate" className="text-sm">
+              내 ETF 목록을 비공개로 설정합니다
+            </label>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Checkbox id="terms" />
+            <Label htmlFor="terms" className="text-sm">
+              이용약관 및 개인정보 처리방침에 동의합니다
+            </Label>
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-col space-y-4">
+          <Button className="w-full" onClick={handleRegister}>
+            회원가입
+          </Button>
+          <div className="text-center text-sm">
+            이미 계정이 있으신가요?{' '}
+            <Link href="/login" className="text-blue-600 hover:underline">
+              로그인
+            </Link>
+          </div>
+        </CardFooter>
+      </Card>
+    </div>
+  );
 }

--- a/front/etf-recommendation/components/EtfCard.tsx
+++ b/front/etf-recommendation/components/EtfCard.tsx
@@ -1,49 +1,61 @@
 'use client';
+
 import Link from 'next/link';
 import { TableRow, TableCell } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 
-type ETF = {
-    id: string;
-    name: string;
-    ticker: string;
-    theme: string;
-    price: number;
-    change: number;
-    volume: number;
-    returnRate: number;
+export type ETF = {
+  id: string;
+  name: string;
+  ticker: string;
+  theme: string;
+  price: number;
+  change: number;
+  volume: number;
+  returnRate: number;
 };
 
 interface Props {
-    etfs: ETF[];
+  etfs: ETF[];
 }
 
 export default function EtfTableBody({ etfs }: Props) {
-    return (
-        <>
-            {etfs.map((etf, index) => (
-                <TableRow key={etf.id} className="cursor-pointer hover:bg-slate-50">
-                    <TableCell className="font-medium">{index + 1}</TableCell>
-                    <TableCell>
-                        <Link href={`/etf/${etf.id}`} className="hover:underline text-blue-600">
-                            {etf.name}
-                        </Link>
-                    </TableCell>
-                    <TableCell>{etf.ticker}</TableCell>
-                    <TableCell>
-                        <Badge variant="outline">{etf.theme}</Badge>
-                    </TableCell>
-                    <TableCell className="text-right">{etf.price.toLocaleString()}원</TableCell>
-                    <TableCell className={`text-right ${etf.change >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                        {etf.change >= 0 ? '+' : ''}
-                        {etf.change.toFixed(2)}%
-                    </TableCell>
-                    <TableCell className="text-right">{etf.volume.toLocaleString()}</TableCell>
-                    <TableCell className="text-right font-bold text-green-600">
-                        +{etf.returnRate.toFixed(2)}%
-                    </TableCell>
-                </TableRow>
-            ))}
-        </>
-    );
+  return (
+    <>
+      {etfs.map((etf, index) => (
+        <TableRow key={etf.id} className="cursor-pointer hover:bg-slate-50">
+          <TableCell className="font-medium">{index + 1}</TableCell>
+          <TableCell>
+            <Link
+              href={`/etf/${etf.id}`}
+              className="hover:underline text-blue-600"
+            >
+              {etf.name}
+            </Link>
+          </TableCell>
+          <TableCell>{etf.ticker}</TableCell>
+          <TableCell>
+            <Badge variant="outline">{etf.theme}</Badge>
+          </TableCell>
+          <TableCell className="text-right">
+            {etf.price.toLocaleString()}원
+          </TableCell>
+          <TableCell
+            className={`text-right ${
+              etf.change >= 0 ? 'text-green-600' : 'text-red-600'
+            }`}
+          >
+            {etf.change >= 0 ? '+' : ''}
+            {etf.change.toFixed(2)}%
+          </TableCell>
+          <TableCell className="text-right">
+            {etf.volume.toLocaleString()}
+          </TableCell>
+          <TableCell className="text-right font-bold text-green-600">
+            +{etf.returnRate.toFixed(2)}%
+          </TableCell>
+        </TableRow>
+      ))}
+    </>
+  );
 }

--- a/front/etf-recommendation/lib/api/auth.ts
+++ b/front/etf-recommendation/lib/api/auth.ts
@@ -21,10 +21,18 @@ export interface LoginResponse {
 export interface UserResponse {
   id: number;
   loginId: string;
-  username: string;
-  email: string;
-  phone: string;
-  profileImageUrl: string | null;
+  nickName: string;
+  imageUrl: string;
+  isLikePrivate: boolean;
+}
+
+export interface UserDetailResponse {
+  id: number;
+  loginId: string;
+  nickName: string;
+  imageUrl: string;
+  isLikePrivate: boolean;
+  createdAt: string;
 }
 
 export interface RefreshTokenResponse {
@@ -59,7 +67,7 @@ export async function register(
 export async function fetchUserProfile(
   loginId: string,
   accessToken?: string
-): Promise<FetchResult<UserResponse>> {
+): Promise<FetchResult<UserDetailResponse>> {
   return get(`/api/v1/users/${loginId}`, {
     errorMessage: '사용자 정보를 불러오는 데 실패했습니다',
     authToken: accessToken,

--- a/front/etf-recommendation/lib/api/auth.ts
+++ b/front/etf-recommendation/lib/api/auth.ts
@@ -1,0 +1,82 @@
+import { FetchResult, post, get } from '../http/client';
+
+export interface LoginRequest {
+  loginId: string;
+  password: string;
+  role: string;
+}
+
+export interface RegisterRequest {
+  loginId: string;
+  password: string;
+  nickname: string;
+  isLikePrivate: boolean;
+}
+
+export interface LoginResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface UserResponse {
+  id: number;
+  loginId: string;
+  username: string;
+  email: string;
+  phone: string;
+  profileImageUrl: string | null;
+}
+
+export interface RefreshTokenResponse {
+  accessToken: string;
+}
+
+/**
+ * 로그인 처리를 합니다.
+ */
+export async function login(
+  credentials: LoginRequest
+): Promise<FetchResult<LoginResponse>> {
+  return post('/api/v1/login', credentials, {
+    errorMessage: '로그인에 실패했습니다',
+  });
+}
+
+/**
+ * 회원가입 처리를 합니다.
+ */
+export async function register(
+  userData: RegisterRequest
+): Promise<FetchResult<UserResponse>> {
+  return post('/api/v1/join', userData, {
+    errorMessage: '회원가입에 실패했습니다',
+  });
+}
+
+/**
+ * 사용자 정보를 가져옵니다.
+ */
+export async function fetchUserProfile(
+  loginId: string,
+  accessToken?: string
+): Promise<FetchResult<UserResponse>> {
+  return get(`/api/v1/users/${loginId}`, {
+    errorMessage: '사용자 정보를 불러오는 데 실패했습니다',
+    authToken: accessToken,
+  });
+}
+
+/**
+ * 토큰을 갱신합니다.
+ */
+export async function refreshToken(): Promise<
+  FetchResult<RefreshTokenResponse>
+> {
+  return post(
+    '/api/v1/refresh',
+    {},
+    {
+      errorMessage: '토큰 갱신에 실패했습니다',
+    }
+  );
+}

--- a/front/etf-recommendation/lib/api/etf.ts
+++ b/front/etf-recommendation/lib/api/etf.ts
@@ -1,0 +1,62 @@
+import { FetchResult, get } from '../http/client';
+
+export interface EtfResponse {
+  totalPage: number;
+  totalCount: number;
+  currentPage: number;
+  pageSize: number;
+  etfReadResponseList: EtfReturnDto[];
+}
+
+interface EtfReturnDto {
+  etfId: number;
+  etfName: string;
+  etfCode: string;
+  theme: string;
+  returnRate: number;
+}
+
+export interface EtfDetailResponse {
+  etfId: number;
+  etfName: string;
+  etfCode: string;
+  companyName: string;
+  listingDate: string;
+}
+
+/**
+ * 모든 ETF 데이터를 가져옵니다.
+ */
+export async function fetchAllEtfs(
+  period: string = 'weekly'
+): Promise<FetchResult<EtfResponse>> {
+  return get('/api/v1/etfs', {
+    params: { page: 1, size: 10000, period },
+    errorMessage: 'ETF 데이터를 불러오는 데 실패했습니다',
+  });
+}
+
+/**
+ * 페이지네이션된 ETF 데이터를 가져옵니다.
+ */
+export async function fetchEtfsPage(
+  page: number = 1,
+  size: number = 20,
+  period: string = 'weekly'
+): Promise<FetchResult<EtfResponse>> {
+  return get('/api/v1/etfs', {
+    params: { page, size, period },
+    errorMessage: 'ETF 페이지 데이터를 불러오는 데 실패했습니다',
+  });
+}
+
+/**
+ * 단일 ETF 상세 정보를 가져옵니다.
+ */
+export async function fetchEtfDetail(
+  etfId: number
+): Promise<FetchResult<EtfDetailResponse>> {
+  return get(`/api/v1/etfs/${etfId}`, {
+    errorMessage: 'ETF 상세 정보를 불러오는 데 실패했습니다',
+  });
+}

--- a/front/etf-recommendation/lib/api/profile.ts
+++ b/front/etf-recommendation/lib/api/profile.ts
@@ -1,0 +1,66 @@
+import { FetchResult, post, get, patch } from '../http/client';
+
+export interface ProfileUpdateRequest {
+  nickName: string;
+  isLikePrivate: boolean;
+}
+
+export interface ProfileResponse {
+  id: number;
+  nickName: string;
+  isLikePrivate: boolean;
+  profileImageUrl?: string;
+  loginId: string;
+}
+
+export interface PasswordChangeRequest {
+  existingPassword: string;
+  newPassword: string;
+  confirmNewPassword: string;
+}
+
+export interface ImageUploadResponse {
+  imageUrl: string;
+}
+
+/**
+ * 프로필을 업데이트합니다.
+ */
+export async function updateUserProfile(
+  userData: ProfileUpdateRequest
+): Promise<FetchResult<ProfileResponse>> {
+  return patch('/api/v1/users', userData, {
+    errorMessage: '프로필 업데이트에 실패했습니다',
+    credentials: 'include',
+  });
+}
+
+/**
+ * 프로필 이미지를 업로드합니다.
+ * @param formData 업로드할 이미지 데이터
+ * @param accessToken 사용자 인증 토큰
+ */
+export async function uploadProfileImage(
+  formData: FormData,
+  accessToken: string
+): Promise<FetchResult<ImageUploadResponse>> {
+  return patch('/api/v1/users/image', formData, {
+    errorMessage: '이미지 업로드에 실패했습니다',
+    authToken: accessToken,
+  });
+}
+
+/**
+ * 비밀번호를 변경합니다.
+ * @param passwordData 비밀번호 변경 데이터
+ * @param accessToken 사용자 인증 토큰
+ */
+export async function changeUserPassword(
+  passwordData: PasswordChangeRequest,
+  accessToken: string
+): Promise<FetchResult<void>> {
+  return patch('/api/v1/users/me/password', passwordData, {
+    errorMessage: '비밀번호 변경에 실패했습니다',
+    authToken: accessToken,
+  });
+}

--- a/front/etf-recommendation/lib/api/subscription.ts
+++ b/front/etf-recommendation/lib/api/subscription.ts
@@ -1,0 +1,62 @@
+import { FetchResult, get, post, deleteRequest } from '../http/client';
+
+export interface SubscriptionResponse {
+  id: number;
+  dtfId: string;
+  createdAt: string;
+  expiredAt: string;
+}
+
+export interface UnsubscribeResponse {
+  etfId: number;
+}
+
+export interface SubscriptionsListResponse {
+  totalPage: number;
+  totalCount: number;
+  currentPage: number;
+  pageSize: number;
+  subscribeResponseList: SubscriptionResponse[];
+}
+
+/**
+ * 특정 ETF를 구독합니다.
+ */
+export async function subscribeToEtf(
+  etfId: number,
+  accessToken: string
+): Promise<FetchResult<SubscriptionResponse>> {
+  return post(
+    `/api/v1/etfs/${etfId}/subscription`,
+    {},
+    {
+      authToken: accessToken,
+      errorMessage: 'ETF 구독에 실패했습니다',
+    }
+  );
+}
+
+/**
+ * 특정 ETF 구독을 취소합니다.
+ */
+export async function unsubscribeFromEtf(
+  etfId: number,
+  accessToken: string
+): Promise<FetchResult<UnsubscribeResponse>> {
+  return deleteRequest(`/api/v1/etf/${etfId}/subscription`, {
+    authToken: accessToken,
+    errorMessage: 'ETF 구독 취소에 실패했습니다',
+  });
+}
+
+/**
+ * 사용자가 구독한 모든 ETF ID 목록을 가져옵니다.
+ */
+export async function fetchSubscribedEtfs(
+  accessToken: string
+): Promise<FetchResult<SubscriptionsListResponse>> {
+  return get('/api/v1/etfs/subscribes', {
+    authToken: accessToken,
+    errorMessage: '구독 정보를 불러오는 데 실패했습니다',
+  });
+}

--- a/front/etf-recommendation/lib/http/client.ts
+++ b/front/etf-recommendation/lib/http/client.ts
@@ -215,6 +215,39 @@ export function post<T, U>(
     ...config,
     method: 'POST',
     headers,
-    body: JSON.stringify(data),
+    body:
+      typeof data === 'string' || data instanceof FormData
+        ? data
+        : JSON.stringify(data),
+  });
+}
+
+export function patch<T, U>(
+  endpoint: string,
+  data: T,
+  config?: BodyRequestConfig
+): Promise<FetchResult<U>> {
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(config?.headers || {}),
+  };
+  return fetchApi<U>(endpoint, {
+    ...config,
+    method: 'PATCH',
+    headers,
+    body:
+      typeof data === 'string' || data instanceof FormData
+        ? data
+        : JSON.stringify(data),
+  });
+}
+
+export function deleteRequest<T>(
+  endpoint: string,
+  config?: ApiRequestConfig
+): Promise<FetchResult<T>> {
+  return fetchApi<T>(endpoint, {
+    ...config,
+    method: 'DELETE',
   });
 }


### PR DESCRIPTION
## 변경 내용
이번 PR에서는 기존에 직접적으로 사용하던 HTTP 클라이언트 메서드 호출 방식을 도메인별 API 클라이언트 메서드를 통해 사용하도록 리팩토링했습니다.

## 변경 이유
1. **관심사 분리**: HTTP 통신 로직과 도메인 로직을 명확히 분리하여 코드 가독성과 유지보수성 향상
2. **추상화 계층 도입**: API 호출에 관한 세부 구현을 추상화하여 클라이언트 코드가 통신 세부사항에 의존하지 않도록 개선
3. **재사용성 증가**: 도메인별 API 클라이언트를 통해 반복되는 코드 감소 및 일관된 에러 처리 가능

## 주요 변경점
- 각 도메인별 API 클라이언트 클래스 생성
- HTTP 요청 로직을 도메인 클라이언트 내부로 캡슐화
- 일관된 에러 처리 및 응답 변환 로직 적용
- 테스트 용이성 향상을 위한 구조 개선

## 참고사항
이 변경으로 인해 API 호출 방식이 변경되었으니 새로운 패턴을 확인해주세요.